### PR TITLE
Add a HasError property to Field

### DIFF
--- a/src/IdParser.Core/Field.cs
+++ b/src/IdParser.Core/Field.cs
@@ -17,7 +17,14 @@ public readonly record struct Field<T>(
     string? RawValue,
     string? Error,
     bool Present
-    );
+    )
+{
+    /// <summary>
+    /// Returns true if the field has a non-null, non-white space <see cref="Error"/> message; false otherwise.
+    /// </summary>
+    public bool HasError
+        => !string.IsNullOrWhiteSpace(Error);
+}
 
 internal static class FieldHelpers
 {

--- a/src/IdParser.Core/IdParser.Core.csproj
+++ b/src/IdParser.Core/IdParser.Core.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		
 		<!-- NuGet -->
-		<Version>2.0.0-alpha3</Version>
+		<Version>2.0.0-alpha4</Version>
 		<AssemblyVersion>2.0.0</AssemblyVersion>
 		<FileVersion>2.0.0</FileVersion>
 		<Authors>Connor O'Shea, Jon Sagara</Authors>


### PR DESCRIPTION
Make it easier on consumers to determine if a Field had a parse error.