### PR TITLE
Fixes #28: In HeightParser, use `ParserHelper.StringHasNoValue` instead of `string.IsNullOrWhiteSpace`

### DIFF
--- a/src/IdParser.Core/IdParser.Core.csproj
+++ b/src/IdParser.Core/IdParser.Core.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<!-- NuGet -->
-		<Version>3.0.0-beta2</Version>
+		<Version>3.0.0-beta3</Version>
 		<AssemblyVersion>3.0.0</AssemblyVersion>
 		<FileVersion>3.0.0</FileVersion>
 		<Authors>Connor O'Shea, Jon Sagara</Authors>

--- a/src/IdParser.Core/Parsers/Id/HeightParser.cs
+++ b/src/IdParser.Core/Parsers/Id/HeightParser.cs
@@ -9,7 +9,7 @@ internal static class HeightParser
     {
         ArgumentNullException.ThrowIfNull(elementId);
 
-        if (string.IsNullOrWhiteSpace(rawValue))
+        if (ParserHelper.StringHasNoValue(rawValue))
         {
             // #28: For 2.0.0, I changed this to return an unparsed field error noting that the field had no value or 
             //   less than 3 characters. AAMVA says that DAU is required, and that when there is no data, it should be


### PR DESCRIPTION
This will correctly identify special "no data" values, such as `NONE`, `unavl`, or `unavail` , in addition to `string.IsNullOrWhiteSpace`.